### PR TITLE
Remove audience validation

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -105,19 +105,6 @@ func ContextIdentity(ctx context.Context) Identity {
 	return nil
 }
 
-// WithServiceName registers the service name to the context
-func WithServiceName(ctx context.Context, service string) context.Context {
-	return context.WithValue(ctx, serviceNameKey, service)
-}
-
-// ContextServiceName gets the service name from the context
-func ContextServiceName(ctx context.Context) string {
-	if v := ctx.Value(serviceNameKey); v != nil {
-		return v.(string)
-	}
-	return ""
-}
-
 func ReadKeyFromFS(logger ErrorLogger, filename string) ([]byte, error) {
 	// Get the secret key
 	var key []byte

--- a/auth_test.go
+++ b/auth_test.go
@@ -173,23 +173,6 @@ var _ = Describe("Auth utilities", func() {
 		})
 	})
 
-	Context("when retrieving service from the context", func() {
-		Context("when the service name is on the context", func() {
-			It("should be retrieved", func() {
-				ctx := WithServiceName(context.Background(), "servicename")
-				received := ContextServiceName(ctx)
-				Ω(received).Should(Equal("servicename"))
-			})
-		})
-		Context("when the service name is not on the context", func() {
-			It("should be empty string", func() {
-				ctx := context.Background()
-				received := ContextServiceName(ctx)
-				Ω(received).Should(Equal(""))
-			})
-		})
-	})
-
 	Context("using the dev mode middleware", func() {
 
 		It("should inject an authorization header when none exists", func() {

--- a/claims/claims.go
+++ b/claims/claims.go
@@ -73,14 +73,6 @@ func ValidateIssuer(claims Claims, issuers []string) error {
 	return nil
 }
 
-// ValidateAudience verifies that the audience in claims contains audience
-func ValidateAudience(claims Claims, audience string) error {
-	if !verifyAudience(claims.Audience(), audience) {
-		return ErrAudience
-	}
-	return nil
-}
-
 func verifyIssuerExists(claimed string) bool {
 	return claimed != ""
 }
@@ -100,15 +92,6 @@ func verifySubject(claimed string) bool {
 
 func verifyAudienceExists(claimed []string) bool {
 	return claimed != nil && len(claimed) > 0
-}
-
-func verifyAudience(claimed []string, audience string) bool {
-	for _, aud := range claimed {
-		if aud == audience {
-			return true
-		}
-	}
-	return false
 }
 
 func verifyExpiresAt(claimed int64, now int64) bool {

--- a/claims/standard.go
+++ b/claims/standard.go
@@ -1,5 +1,7 @@
 package claims
 
+import "time"
+
 var (
 	// standardClaimsMap defines the shape and fields for a map containing
 	// standard JWT claims
@@ -89,10 +91,8 @@ func (m StandardClaimsMap) Valid() error {
 func (m StandardClaimsMap) Validate(issuers []string, audience string) error {
 	if err := m.Valid(); err != nil {
 		return err
-	} else if err := ValidateIssuer(m, issuers); err != nil {
-		return err
 	}
-	return ValidateAudience(m, audience)
+	return ValidateIssuer(m, issuers)
 }
 
 // StandardClaims implements registered claim names according to RFC 7519
@@ -104,6 +104,20 @@ type StandardClaims struct {
 	Nbf int64    `json:"nbf"`
 	Iat int64    `json:"iat"`
 	Jti string   `json:"jti"`
+}
+
+// NewStandardClaims creates a new StandardClaims
+func NewStandardClaims(iss, sub string, aud []string) StandardClaims {
+	now := time.Now()
+	return StandardClaims{
+		Iss: iss,
+		Sub: sub,
+		Aud: aud,
+		Exp: now.Add(ValidDuration).Unix(),
+		Nbf: now.Unix(),
+		Iat: now.Unix(),
+		Jti: "0",
+	}
 }
 
 // StandardClaimsFromMap assumes m is Valid and
@@ -165,8 +179,6 @@ func (claims StandardClaims) Valid() error {
 func (claims StandardClaims) Validate(issuers []string, audience string) error {
 	if err := claims.Valid(); err != nil {
 		return err
-	} else if err := ValidateIssuer(claims, issuers); err != nil {
-		return err
 	}
-	return ValidateAudience(claims, audience)
+	return ValidateIssuer(claims, issuers)
 }

--- a/claims/standard_test.go
+++ b/claims/standard_test.go
@@ -9,19 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func newStandardClaims() StandardClaims {
-	now := time.Now()
-	return StandardClaims{
-		Iss: "someone",
-		Sub: "abcd",
-		Aud: []string{"tester"},
-		Exp: now.Add(ValidDuration).Unix(),
-		Nbf: now.Unix(),
-		Iat: now.Unix(),
-		Jti: "0",
-	}
-}
-
 func newStandardClaimsMap() StandardClaimsMap {
 	now := time.Now()
 	return StandardClaimsMap{
@@ -38,13 +25,13 @@ func newStandardClaimsMap() StandardClaimsMap {
 var _ = Describe("Standard Claims", func() {
 	var (
 		now           = time.Now().Unix()
-		claims        = newStandardClaims()
+		claims        = NewStandardClaims("someone", "abcd", []string{"tester"})
 		claimsMap     = newStandardClaimsMap()
 		validIssuers  = []string{"someone"}
 		validAudience = "tester"
 	)
 	BeforeEach(func() {
-		claims = newStandardClaims()
+		claims = NewStandardClaims("someone", "abcd", []string{"tester"})
 		claimsMap = newStandardClaimsMap()
 	})
 	Context("when creating a StandardClaimsMap", func() {
@@ -205,15 +192,6 @@ var _ = Describe("Standard Claims", func() {
 				It("should return an error", func() {
 					err := claims.Validate(validIssuers, validAudience)
 					Ω(err).Should(Equal(ErrIssuer))
-				})
-			})
-			Context("when the audience is not valid", func() {
-				BeforeEach(func() {
-					claims.Aud = []string{"keanu"}
-				})
-				It("should return an error", func() {
-					err := claims.Validate(validIssuers, validAudience)
-					Ω(err).Should(Equal(ErrAudience))
 				})
 			})
 			Context("when the token is expired", func() {


### PR DESCRIPTION
Remove how we validate audience, so audience can be for domain specific purposes, e.g. for a tenant id in our case.

Also, remove ContextServiceName, since it was only there to validate audience against the service's name.

Also, add "New" func for StandardClaims.