### PR TITLE
Add check for tenant

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -55,6 +55,14 @@ func JWTValidatorFunc(m JWTValidator) goa.Middleware {
 			ident := &tokenIdentity{stdClaims}
 			ctx = WithIdentity(ctx, ident)
 			ctx = goa.WithLogContext(ctx, "user_id", ident.ID())
+			if len(ident.Tenant()) == 0 {
+				message := "Unable to retrieve tenant from token"
+				logger := ContextLogger(ctx)
+				if logger != nil {
+					logger.Debug(message)
+				}
+				return errors.WithStack(errors.New(message))
+			}
 			return h(ctx, rw, req)
 		}
 	}
@@ -132,6 +140,29 @@ const (
 )
 
 const (
-	// This token is signed with the secret "secret" and gives the bearer the scopes "api:admin api:access"
+	/*
+		This token is signed with the secret "secret" and gives the bearer the scopes "api:admin api:access"
+
+		HEADER:
+
+		{
+		  "alg": "HS256",
+		  "typ": "JWT"
+		}
+
+		PAYLOAD:
+		{
+			"iss": "Auth0",
+			"sub": "1",
+			"aud": [
+				"anyone"
+			],
+			"exp": 1605511786,
+			"nbf": 1505425386,
+			"iat": 1505425386,
+			"jti": "1",
+			"scopes": "api:admin api:access"
+		}
+	*/
 	devJWT = `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJBdXRoMCIsInN1YiI6IjEiLCJhdWQiOlsiYW55b25lIl0sImV4cCI6MTYwNTUxMTc4NiwibmJmIjoxNTA1NDI1Mzg2LCJpYXQiOjE1MDU0MjUzODYsImp0aSI6IjEiLCJzY29wZXMiOiJhcGk6YWRtaW4gYXBpOmFjY2VzcyJ9.cmw2-w7efRhtNMDXypaI84UYHFZ_CmG0m9Jb6SnzX1Q`
 )

--- a/auth_test.go
+++ b/auth_test.go
@@ -227,32 +227,36 @@ var _ = Describe("Auth utilities", func() {
 		})
 
 		Context("using the default validator middleware", func() {
-			JustBeforeEach(func() {
-				id = test.RandString(8)
-				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", signedToken()))
-				ctx := context.Background()
-				err := getHandler(DefaultJWTValidation)(ctx, resp, req)
-				Ω(err).ShouldNot(HaveOccurred())
-			})
+			Context("and the audience is correct", func() {
+				JustBeforeEach(func() {
+					id = test.RandString(8)
+					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", signedToken()))
+					ctx := context.Background()
+					err := getHandler(DefaultJWTValidation)(ctx, resp, req)
+					Ω(err).ShouldNot(HaveOccurred())
+				})
 
-			It("should pass the id through the context", func() {
-				Ω(ident).ShouldNot(BeNil())
-				Ω(ident.ID()).Should(Equal(id))
-			})
+				It("should pass the id through the context", func() {
+					Ω(ident).ShouldNot(BeNil())
+					Ω(ident.ID()).Should(Equal(id))
+				})
 
-			It("should pass the tenant through the context", func() {
-				Ω(ident).ShouldNot(BeNil())
-				Ω(ident.Tenant()).Should(Equal("tenant"))
+				It("should pass the tenant through the context", func() {
+					Ω(ident).ShouldNot(BeNil())
+					Ω(ident.Tenant()).Should(Equal("tenant"))
+				})
 			})
 
 			Context("and the audience is incorrect", func() {
 				BeforeEach(func() {
+					id = test.RandString(8)
 					audience = []string{"more", "than", "one", "value"}
+					req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", signedToken()))
 				})
 
-				It("should return empty for tenant", func() {
-					Ω(ident).ShouldNot(BeNil())
-					Ω(ident.Tenant()).Should(BeEmpty())
+				It("should return an error", func() {
+					err := getHandler(DefaultJWTValidation)(context.Background(), resp, req)
+					Ω(err).Should(HaveOccurred())
 				})
 			})
 		})


### PR DESCRIPTION
Adding a check for the tenant ID in the JWT.  If it is not present, the authentication will fail.