### PR TITLE
Pin docker version to fix missing package

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -21,6 +21,8 @@ import:
   - labels
   - project
   - project/options
+- package: github.com/docker/docker
+  version: 777d4a1bf45c85db6931205d4adbe38a17c583d7 
 - package: github.com/goadesign/goa
   version: 0ad2e960bfbfb49cf94d3ce689a9426ef006babb
   subpackages:


### PR DESCRIPTION
A package (docker/pkg/promise) was removed from docker that broke dependencies.  This will pin docker to a version which still has that package.