### PR TITLE
Add a common SchemaRegistry

### DIFF
--- a/databus/schema_registry.go
+++ b/databus/schema_registry.go
@@ -1,0 +1,138 @@
+package databus
+
+import (
+	"context"
+	"strings"
+
+	schemaregistry "github.com/datamountaineer/schema-registry"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/zenoss/zenkit"
+)
+
+var (
+	schemaRegistryFactoryKey = "schema_registry_factory"
+
+	// ErrFactoryNotFound occurs when the schema registry factory is not on the context
+	ErrFactoryNotFound = errors.New("schema registry factory not found on context")
+)
+
+// WithSchemaRegistryFactory returns the context with a schema registry factory attached
+// Example:
+// service.Context = databus.WithSchemaRegistryFactory(service.Context, databus.DefaultSchemaRegistryFactory(service.Context))
+func WithSchemaRegistryFactory(ctx context.Context, f SchemaRegistryFactory) context.Context {
+	return context.WithValue(ctx, schemaRegistryFactoryKey, f)
+}
+
+// ContextSchemaRegistryFactory returns the schema registry factory attached to the context
+func ContextSchemaRegistryFactory(ctx context.Context) (SchemaRegistryFactory, error) {
+	if v := ctx.Value(schemaRegistryFactoryKey); v != nil {
+		tf := v.(SchemaRegistryFactory)
+		return tf, nil
+	}
+	return nil, ErrFactoryNotFound
+}
+
+// SchemaRegistry can be used to register kafka key and value schema's.
+type SchemaRegistry interface {
+	Register(KeySubject string, KeySchema string, ValueSubject string, ValueSchema string) error
+}
+
+// SchemaRegistryFactory can be used to generate new instances of SchemaRegistry
+type SchemaRegistryFactory interface {
+	NewSchemaRegistry(registryURI string) SchemaRegistry
+}
+
+type defaultRegistry struct {
+	logger        *logrus.Logger
+	registryURI   string
+	newClientFunc NewSchemaRegistryClientFunc
+}
+
+type defaultRegistryFactory struct {
+	newClientFunc NewSchemaRegistryClientFunc
+	logger        *logrus.Logger
+}
+
+// DefaultSchemaRegistryFactory returns a default implementation of the SchemaRegistryFactory,
+// which uses the Logger from the specified context.
+func DefaultSchemaRegistryFactory(ctx context.Context) SchemaRegistryFactory {
+	return BuildSchemaRegistryFactory(ctx, schemaregistry.NewClient)
+}
+
+// NewSchemaRegistryClient is a function that can be used to generate new clients for the schema registry
+// Note this type primarily exists for unit-testing within this package.
+type NewSchemaRegistryClientFunc func(baseurl string) (schemaregistry.Client, error)
+
+// BuildSchemaRegistryFactory returns a default implementation of SchemaRegistryFactory
+// with a caller-specified NewSchemaRegistryClientFunc.
+// This method is primarily intended for unit-testing this package. Users of this package are encouraged
+// to use the simpler DefaultSchemaRegistryFactory() method instead of this method.
+func BuildSchemaRegistryFactory(ctx context.Context, newClientFunc NewSchemaRegistryClientFunc) SchemaRegistryFactory {
+	return &defaultRegistryFactory{
+		newClientFunc: newClientFunc,
+		logger:        zenkit.ContextLogger(ctx).Logger,
+	}
+}
+
+// NewSchemaRegistry returns a default implementation of SchemaRegistry
+// which uses the Logger from defaultRegistryFactory
+func (f *defaultRegistryFactory) NewSchemaRegistry(registryURI string) SchemaRegistry {
+	return &defaultRegistry{
+		logger:        f.logger,
+		newClientFunc: f.newClientFunc,
+		registryURI:   registryURI,
+	}
+}
+
+func (r *defaultRegistry) Register(KeySubject string, KeySchema string, ValueSubject string, ValueSchema string) error {
+	client, err := r.newClientFunc(r.registryURI)
+	if err != nil {
+		return errors.Wrap(err, "failed to create schema registry client")
+	}
+
+	err = r.register(client, KeySubject, KeySchema)
+	if err != nil {
+		return errors.Wrap(err, "failed to register key")
+	}
+
+	err = r.register(client, ValueSubject, ValueSchema)
+	if err != nil {
+		return errors.Wrap(err, "failed to register value")
+	}
+
+	return nil
+}
+
+func (r *defaultRegistry) register(client schemaregistry.Client, subject, schema string) error {
+	logger := r.logger.WithFields(logrus.Fields{
+		"registry": r.registryURI,
+		"subject": subject,
+		"schema": schema,
+	})
+
+	registered, _, err := client.IsRegistered(subject, schema)
+	if err != nil {
+		// If a schema for the subject has never been registered before, the IsRegistered method
+		// will return an error.  In this case, we want to register the schema.  We don't have access
+		// to the underlying error type to get the error code for this situation (which is 40401) so we
+		// will check the message for the error code.
+		if !strings.Contains(err.Error(), "40401") {
+			logger.WithError(err).Error("Error occurred checking schema registration")
+			return err
+		}
+	}
+
+	if !registered {
+		_, err = client.RegisterNewSchema(subject, schema)
+		if err != nil {
+			logger.WithError(err).Error("Error occurred registering new schema")
+			return err
+		}
+		logger.Info("New schema registered")
+	} else {
+		logger.Debug("Schema already registered")
+	}
+
+	return nil
+}

--- a/databus/schema_registry.go
+++ b/databus/schema_registry.go
@@ -10,9 +10,14 @@ import (
 	"github.com/zenoss/zenkit"
 )
 
-var (
-	schemaRegistryFactoryKey = "schema_registry_factory"
+// key is the type used to store internal values in the context.
+type key int
 
+const (
+	schemaRegistryFactoryKey key = iota + 1
+)
+
+var (
 	// ErrFactoryNotFound occurs when the schema registry factory is not on the context
 	ErrFactoryNotFound = errors.New("schema registry factory not found on context")
 )

--- a/databus/schema_registry_test.go
+++ b/databus/schema_registry_test.go
@@ -1,0 +1,199 @@
+package databus_test
+
+import (
+	"context"
+
+	schemaregistry "github.com/datamountaineer/schema-registry"
+	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/logging/logrus"
+	"github.com/pkg/errors"
+	"github.com/zenoss/zenkit/test"
+	. "github.com/zenoss/zenkit/databus"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+type mockFactory struct {
+	registry SchemaRegistry
+}
+
+func (mock *mockFactory) NewSchemaRegistry(registryURI string) SchemaRegistry {
+	return mock.registry
+}
+
+var _ = Describe("Registry", func() {
+
+	var (
+		ctx context.Context
+		factory SchemaRegistryFactory
+		client *schemaregistry.MockClient
+		registry SchemaRegistry
+		newClientFunc NewSchemaRegistryClientFunc
+		logger   = test.TestLogger()
+
+		testSubject, testSchema string
+		isRegisteredError, registrationError error
+
+		isRegisteredMock = func(subject, schema string) (bool, schemaregistry.Schema, error) {
+			unused := schemaregistry.Schema{}
+			if subject == testSubject && schema == testSchema {
+				return false, unused, isRegisteredError
+			}
+			return true, unused, nil
+		}
+
+		registerNewSchemaMock = func(subject, schema string) (int, error) {
+			Ω(subject).Should(Equal(testSubject))
+			Ω(schema).Should(Equal(testSchema))
+			return 0, registrationError
+		}
+	)
+
+	BeforeEach(func() {
+		ctx = goa.WithLogger(context.Background(), goalogrus.New(logger))
+	})
+
+	Context("when a schema registry factory is added to a context", func() {
+		JustBeforeEach(func() {
+			factory = DefaultSchemaRegistryFactory(ctx)
+			ctx = WithSchemaRegistryFactory(ctx, factory)
+		})
+		It("it can be retrieved from such context", func() {
+			result, err := ContextSchemaRegistryFactory(ctx)
+			Ω(err).Should(BeNil())
+			Ω(result).Should(Equal(factory))
+		})
+	})
+
+	Context("when a schema registry factory is not added to a context", func() {
+		It("retrieving it from the context fails", func() {
+			result, err := ContextSchemaRegistryFactory(ctx)
+			Ω(err).ShouldNot(BeNil())
+			Ω(err).Should(Equal(ErrFactoryNotFound))
+			Ω(result).Should(BeNil())
+		})
+	})
+
+	Context("when a schema registry client cannot be created", func() {
+		expectedError := errors.New("new client func failed")
+		JustBeforeEach(func() {
+			newClientFunc =  func(baseurl string) (schemaregistry.Client, error) {
+				return nil, expectedError
+			}
+			factory = BuildSchemaRegistryFactory(ctx, newClientFunc)
+			Ω(factory).ShouldNot(BeNil())
+			registry = factory.NewSchemaRegistry("registryURI")
+		})
+		It("schema registration should fail", func() {
+			err := registry.Register("unused", "unused", "unused", "unused")
+			Ω(err).ShouldNot(BeNil())
+			Ω(errors.Cause(err)).Should(Equal(expectedError))
+		})
+	})
+
+	Context("when a key schema is registered", func() {
+		JustBeforeEach(func() {
+			testSubject = "keySubject"
+			testSchema = "keySchema"
+			client = &schemaregistry.MockClient{
+				IsRegisteredFn:      isRegisteredMock,
+				RegisterNewSchemaFn: registerNewSchemaMock,
+			}
+			newClientFunc =  func(baseurl string) (schemaregistry.Client, error) {
+				return client, nil
+			}
+			factory = BuildSchemaRegistryFactory(ctx, newClientFunc)
+			Ω(factory).ShouldNot(BeNil())
+
+			registry = factory.NewSchemaRegistry("registryURI")
+		})
+
+		Context("and it has not been registered before", func() {
+			JustBeforeEach(func() {
+				isRegisteredError = errors.New("40401")
+				registrationError = nil
+			})
+			It("it should be added to the registry", func() {
+				err := registry.Register(testSubject, testSchema, "unused", "unused")
+				Ω(err).Should(BeNil())
+			})
+		})
+
+		Context("and the registry check fails", func() {
+			JustBeforeEach(func() {
+				isRegisteredError = errors.New("check failed")
+			})
+			It("it should not be added to the registry", func() {
+				err := registry.Register(testSubject, testSchema, "unused", "unused")
+				Ω(err).ShouldNot(BeNil())
+				Ω(errors.Cause(err)).Should(Equal(isRegisteredError))
+			})
+		})
+
+		Context("and registration fails", func() {
+			JustBeforeEach(func() {
+				isRegisteredError = errors.New("40401")
+				registrationError = errors.New("registration failed")
+			})
+			It("it should not be added to the registry", func() {
+				err := registry.Register(testSubject, testSchema, "unused", "unused")
+				Ω(err).ShouldNot(BeNil())
+				Ω(errors.Cause(err)).Should(Equal(registrationError))
+			})
+		})
+	})
+
+	Context("when a value schema is registered", func() {
+		JustBeforeEach(func() {
+			testSubject = "valueSubject"
+			testSchema = "valueSchema"
+			client = &schemaregistry.MockClient{
+				IsRegisteredFn:      isRegisteredMock,
+				RegisterNewSchemaFn: registerNewSchemaMock,
+			}
+			newClientFunc =  func(baseurl string) (schemaregistry.Client, error) {
+				return client, nil
+			}
+			factory = BuildSchemaRegistryFactory(ctx, newClientFunc)
+			Ω(factory).ShouldNot(BeNil())
+
+			registry = factory.NewSchemaRegistry("registryURI")
+		})
+
+		Context("and it has not been registered before", func() {
+			JustBeforeEach(func() {
+				isRegisteredError = errors.New("40401")
+				registrationError = nil
+			})
+			It("it should be added to the registry", func() {
+				err := registry.Register("unused", "unused", testSubject, testSchema)
+				Ω(err).Should(BeNil())
+			})
+		})
+
+		Context("and the registry check fails", func() {
+			JustBeforeEach(func() {
+				isRegisteredError = errors.New("check failed")
+			})
+			It("it should not be added to the registry", func() {
+				err := registry.Register("unused", "unused", testSubject, testSchema)
+				Ω(err).ShouldNot(BeNil())
+				Ω(errors.Cause(err)).Should(Equal(isRegisteredError))
+			})
+		})
+
+		Context("and registration fails", func() {
+			JustBeforeEach(func() {
+				isRegisteredError = errors.New("40401")
+				registrationError = errors.New("registration failed")
+			})
+			It("it should not be added to the registry", func() {
+				err := registry.Register("unused", "unused", testSubject, testSchema)
+				Ω(err).ShouldNot(BeNil())
+				Ω(errors.Cause(err)).Should(Equal(registrationError))
+			})
+		})
+	})
+})
+
+


### PR DESCRIPTION
To use in a micro service, you would register the default schemaregistry factory in your server initialization like this:
```
service.Context = databus.WithSchemaRegistryFactory(service.Context, databus.DefaultSchemaRegistryFactory(service.Context))
```

To use in a REST handler, you would retrieve the factory like this:
```
factory, err := ContextSchemaRegistryFactory(ctx)
if err != nil {
    logger.WithError(err).Error("Could not retrieve schema registry factory")
    return ctx.InternalServerError(err)
}
registry := factory.NewSchemaRegistry(registryURI)
```
