### PR TITLE
Add new signer

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -2,12 +2,9 @@ package auth
 
 import (
 	"context"
-	"net/http"
-	"strings"
 	"time"
 
 	jwtgo "github.com/dgrijalva/jwt-go"
-	"github.com/goadesign/goa/client"
 	"github.com/goadesign/goa/design"
 	"github.com/goadesign/goa/design/apidsl"
 	"github.com/spf13/afero"
@@ -51,22 +48,6 @@ func JWT() *design.SecuritySchemeDefinition {
 		})
 	}
 	return localJWT
-}
-
-func JWTSigner(req *http.Request) *client.JWTSigner {
-	token := &client.StaticToken{}
-
-	parts := strings.Fields(req.Header.Get("Authorization"))
-	switch len(parts) {
-	case 0:
-		return nil
-	case 1:
-		token.Value = parts[0]
-	default:
-		token.Type = parts[0]
-		token.Value = strings.Join(parts[1:], " ")
-	}
-	return &client.JWTSigner{TokenSource: &client.StaticTokenSource{StaticToken: token}}
 }
 
 func BuildDevToken(ctx context.Context, signingMethod jwtgo.SigningMethod) string {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -111,11 +111,12 @@ PZ7f7nhaGd0pr6KF1z/GJUA2IpgsZ/pzJmAO3BZMAFfzp3u2kpBRry+BUXf5xg+3
 xhcmeuiFwygRmLe2q0SQ1n6ekrw+RcIHfsWxqq6A028/N8GqGdbcJ5qL5ITEKJZT
 BMUjCjMj7krg2mdNb3PmGN97AtEelKgC8RRdlswCdPQkFVQq2tBfPXrckdMHO18=
 -----END CERTIFICATE-----`)
-		rsaFile *os.File
-		svc     *goa.Service
-		resp    *httptest.ResponseRecorder
-		req     *http.Request
-		handler = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+		rsaFile   *os.File
+		svc       *goa.Service
+		resp      *httptest.ResponseRecorder
+		req       *http.Request
+		claimsCtx context.Context
+		handler   = func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
 			token = jwt.ContextJWT(ctx)
 			ident = ContextIdentity(ctx)
 			return nil
@@ -135,6 +136,7 @@ BMUjCjMj7krg2mdNb3PmGN97AtEelKgC8RRdlswCdPQkFVQq2tBfPXrckdMHO18=
 		req, _ = http.NewRequest("", "http://example.com/", nil)
 		resp = httptest.NewRecorder()
 		audience = []string{"tenant"}
+		claimsCtx = context.Background()
 	})
 
 	JustBeforeEach(func() {
@@ -306,10 +308,15 @@ BMUjCjMj7krg2mdNb3PmGN97AtEelKgC8RRdlswCdPQkFVQq2tBfPXrckdMHO18=
 
 	Context("signing with a dynamic signer", func() {
 		claimsFunc := func() (jwtpkg.Claims, error) {
-			return newClaims(id, audience), nil
+			ctxIdent := ContextIdentity(claimsCtx)
+			return newClaims(ctxIdent.ID(), []string{ctxIdent.Tenant()}), nil
 		}
 		signer := &DynamicSigner{}
 		BeforeEach(func() {
+			claimsCtx = WithIdentity(context.Background(), &testIdentity{
+				id,
+				audience[0],
+			})
 			signer = NewSigner(claimsFunc, jwtpkg.SigningMethodHS256, secret)
 			req.Header.Set("Authorization", "abc123")
 		})
@@ -330,6 +337,12 @@ BMUjCjMj7krg2mdNb3PmGN97AtEelKgC8RRdlswCdPQkFVQq2tBfPXrckdMHO18=
 			Context("with a valid secret", func() {
 				BeforeEach(func() {
 					signer.Secret = secret
+					id = "abcd"
+					audience = []string{"tenant"}
+					claimsCtx = WithIdentity(context.Background(), &testIdentity{
+						id,
+						audience[0],
+					})
 				})
 				It("should return a Signer, that puts a good token in request headers", func() {
 					err := signer.Sign(req)

--- a/auth/signer.go
+++ b/auth/signer.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/goadesign/goa/client"
+	"github.com/pkg/errors"
+
+	jwtgo "github.com/dgrijalva/jwt-go"
+)
+
+// ClaimsFunc is used by DynamicSigner to get claims at signing time
+type ClaimsFunc func() (jwtgo.Claims, error)
+
+// DynamicSigner is a goa client.Signer that gets claims at signing time,
+// which allows a single signer to be used for multiple identities
+type DynamicSigner struct {
+	ClaimsFunc ClaimsFunc
+	Method     jwtgo.SigningMethod
+	Secret     []byte
+	KeyName    string
+	KeyFormat  string
+}
+
+// NewSigner creates a DynamicSigner for the claimsFunc, signing method, and secret
+func NewSigner(claimsFunc ClaimsFunc, signingMethod jwtgo.SigningMethod, secret []byte) *DynamicSigner {
+	return &DynamicSigner{
+		ClaimsFunc: claimsFunc,
+		Method:     signingMethod,
+		Secret:     secret,
+		KeyName:    "Authorization",
+		KeyFormat:  "Bearer %s",
+	}
+}
+
+// Sign signs the request header and satisfies the goa client Signer interface
+func (signer *DynamicSigner) Sign(r *http.Request) error {
+	claims, err := signer.ClaimsFunc()
+	if err != nil {
+		return errors.Wrap(err, "unable to get claims")
+	}
+
+	token := jwtgo.NewWithClaims(signer.Method, claims)
+	key, err := token.SignedString(signer.Secret)
+	if err != nil {
+		return errors.Wrap(err, "unable to sign with provided secret")
+	}
+
+	r.Header.Set(signer.KeyName, fmt.Sprintf(signer.KeyFormat, key))
+	return nil
+}
+
+// JWTSigner returns a signer that signs with the jwt on req
+func JWTSigner(req *http.Request) *client.JWTSigner {
+	token := &client.StaticToken{}
+
+	parts := strings.Fields(req.Header.Get("Authorization"))
+	switch len(parts) {
+	case 0:
+		return nil
+	case 1:
+		token.Value = parts[0]
+	default:
+		token.Type = parts[0]
+		token.Value = strings.Join(parts[1:], " ")
+	}
+	return &client.JWTSigner{TokenSource: &client.StaticTokenSource{StaticToken: token}}
+}


### PR DESCRIPTION
clients generated by goa use a Signer (interface with Sign method), but the signer types built into goa just reuse the same token.
DynamicSigner provides the ability to generate a token at signing, allowing us to read things (such as an Identity) off of the context.