### PR TITLE
Pin libcompose dependency versions to those specified in libcompose's own vendor.conf

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -23,6 +23,16 @@ import:
   - project/options
 - package: github.com/docker/docker
   version: 75c7536d2e2e328b644bf69153de879d1d197988
+- package: github.com/docker/cli
+  version: d95fd2f38cfc23e077530c6181330727d561b6a0
+- package: github.com/docker/distribution
+  version: b38e5838b7b2f2ad48e06ec4b500011976080621
+- package: github.com/docker/go-connections
+  version: e15c02316c12de00874640cd76311849de2aeed5
+- package: github.com/docker/go-units
+  version: 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
+- package: github.com/docker/libtrust
+  version: 9cbd2a1374f46905c68a4eb3694a130610adc62a
 - package: github.com/goadesign/goa
   version: 0ad2e960bfbfb49cf94d3ce689a9426ef006babb
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,7 +11,7 @@ import:
 - package: github.com/dgrijalva/jwt-go
   version: 3.0.0
 - package: github.com/docker/libcompose
-  version: 1b708aac26a4fc6f9bff31728a8e3a252ef57dbd
+  version: b2c0c6e7006959f15d7d3f64a653a339a4b68ff3
   subpackages:
   - config
   - docker
@@ -22,7 +22,7 @@ import:
   - project
   - project/options
 - package: github.com/docker/docker
-  version: df423d57936bf6e94bb1e54892f5419e1d927708
+  version: 75c7536d2e2e328b644bf69153de879d1d197988
 - package: github.com/goadesign/goa
   version: 0ad2e960bfbfb49cf94d3ce689a9426ef006babb
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -22,7 +22,7 @@ import:
   - project
   - project/options
 - package: github.com/docker/docker
-  version: 777d4a1bf45c85db6931205d4adbe38a17c583d7 
+  version: df423d57936bf6e94bb1e54892f5419e1d927708
 - package: github.com/goadesign/goa
   version: 0ad2e960bfbfb49cf94d3ce689a9426ef006babb
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -33,6 +33,12 @@ import:
   version: 9e638d38cf6977a37a8ea0078f3ee75a7cdb2dd1
 - package: github.com/docker/libtrust
   version: 9cbd2a1374f46905c68a4eb3694a130610adc62a
+- package: github.com/xeipuuv/gojsonschema
+  version: 93e72a773fade158921402d6a24c819b48aba29d
+- package: github.com/xeipuuv/gojsonpointer
+  version: e0fe6f68307607d540ed8eac07a342c33fa1b54a
+- package: github.com/xeipuuv/gojsonreference
+  version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - package: github.com/goadesign/goa
   version: 0ad2e960bfbfb49cf94d3ce689a9426ef006babb
   subpackages:


### PR DESCRIPTION
https://github.com/docker/libcompose/blob/master/vendor.conf was the source.