### PR TITLE
Add --gcloud-use-emulator option

### DIFF
--- a/config.go
+++ b/config.go
@@ -26,6 +26,7 @@ const (
 
 	GCProjectIDConfig         = "gcloud.project_id"
 	GCNoAuthConfig            = "gcloud.no_auth"
+	GCUseEmulatorConfig       = "gcloud.use_emulator"
 	GCEmulatorBigtableConfig  = "gcloud.emulator.bigtable"
 	GCEmulatorDatastoreConfig = "gcloud.emulator.datastore"
 	GCEmulatorPubsubConfig    = "gcloud.emulator.pubsub"
@@ -114,6 +115,10 @@ func AddGCloudEmulatorDatastoreOptions(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("gcloud-emulator-datastore", "", "Host:port of the gcloud datastore emulator")
 	viper.BindPFlag(GCEmulatorDatastoreConfig, cmd.PersistentFlags().Lookup("gcloud-emulator-datastore"))
 	viper.SetDefault(GCEmulatorDatastoreConfig, "")
+
+	cmd.PersistentFlags().Bool("gcloud-use-emulator", false, "Use gcloud datastore emulator")
+	viper.BindPFlag(GCUseEmulatorConfig, cmd.PersistentFlags().Lookup("gcloud-use-emulator"))
+	viper.SetDefault(GCUseEmulatorConfig, false)
 }
 
 func AddGCloudEmulatorPubsubOptions(cmd *cobra.Command) {

--- a/config_test.go
+++ b/config_test.go
@@ -275,10 +275,21 @@ var _ = Describe("Config", func() {
 			Ω(viper.GetString(GCEmulatorDatastoreConfig)).Should(Equal("host:9001"))
 		})
 
+		It("should allow enabling the datastore emulator via env var", func() {
+			setenv("GCLOUD_USE_EMULATOR", "1")
+			Ω(viper.GetBool(GCUseEmulatorConfig)).Should(BeTrue())
+		})
+
 		It("should allow setting the datastore host via command line", func() {
 			err := cmd.ParseFlags([]string{"--gcloud-emulator-datastore", "host:9001"})
 			Ω(err).ShouldNot(HaveOccurred())
 			Ω(viper.GetString(GCEmulatorDatastoreConfig)).Should(Equal("host:9001"))
+		})
+
+		It("should allow enabling datastore emulator via command line", func() {
+			err := cmd.ParseFlags([]string{"--gcloud-use-emulator", "1"})
+			Ω(err).ShouldNot(HaveOccurred())
+			Ω(viper.GetBool(GCUseEmulatorConfig)).Should(BeTrue())
 		})
 
 		It("should allow setting the pubsub host via command line", func() {


### PR DESCRIPTION
Defaults to false

Used to select the datastore emulator instead of
a live connection the the datastore