### PR TITLE
Renamed gcloud.emulator.datastore to g.e.d.host-port

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,12 +24,12 @@ const (
 	HTTPPortConfig  = "http.port"
 	AdminPortConfig = "admin.port"
 
-	GCProjectIDConfig                = "gcloud.project_id"
-	GCDatastoreCredentialsConfig     = "gcloud.datastore.credentials"
-	GCEmulatorBigtableConfig         = "gcloud.emulator.bigtable"
-	GCEmulatorDatastoreConfig        = "gcloud.emulator.datastore"
-	GCEmulatorDatastoreEnabledConfig = "gcloud.emulator.datastore.enabled"
-	GCEmulatorPubsubConfig           = "gcloud.emulator.pubsub"
+	GCProjectIDConfig                 = "gcloud.project_id"
+	GCDatastoreCredentialsConfig      = "gcloud.datastore.credentials"
+	GCEmulatorBigtableConfig          = "gcloud.emulator.bigtable"
+	GCEmulatorDatastoreEnabledConfig  = "gcloud.emulator.datastore.enabled"
+	GCEmulatorDatastoreHostPortConfig = "gcloud.emulator.datastore.host_port"
+	GCEmulatorPubsubConfig            = "gcloud.emulator.pubsub"
 )
 
 func AddStandardServerOptions(cmd *cobra.Command, port, adminPort int) {
@@ -108,9 +108,9 @@ func AddGCloudEmulatorBigtableOptions(cmd *cobra.Command) {
 }
 
 func AddGCloudEmulatorDatastoreOptions(cmd *cobra.Command) {
-	cmd.PersistentFlags().String("gcloud-emulator-datastore", "", "Host:port of the gcloud datastore emulator")
-	viper.BindPFlag(GCEmulatorDatastoreConfig, cmd.PersistentFlags().Lookup("gcloud-emulator-datastore"))
-	viper.SetDefault(GCEmulatorDatastoreConfig, "")
+	cmd.PersistentFlags().String("gcloud-emulator-datastore-host-port", "", "Host:port of the gcloud datastore emulator")
+	viper.BindPFlag(GCEmulatorDatastoreHostPortConfig, cmd.PersistentFlags().Lookup("gcloud-emulator-datastore-host-port"))
+	viper.SetDefault(GCEmulatorDatastoreHostPortConfig, "")
 
 	cmd.PersistentFlags().Bool("gcloud-emulator-datastore-enabled", false, "Use gcloud datastore emulator")
 	viper.BindPFlag(GCEmulatorDatastoreEnabledConfig, cmd.PersistentFlags().Lookup("gcloud-emulator-datastore-enabled"))

--- a/config_test.go
+++ b/config_test.go
@@ -256,8 +256,8 @@ var _ = Describe("Config", func() {
 		})
 
 		It("should allow setting the datastore host via env var", func() {
-			setenv("GCLOUD_EMULATOR_DATASTORE", "host:9001")
-			Ω(viper.GetString(GCEmulatorDatastoreConfig)).Should(Equal("host:9001"))
+			setenv("GCLOUD_EMULATOR_DATASTORE_HOST_PORT", "host:9001")
+			Ω(viper.GetString(GCEmulatorDatastoreHostPortConfig)).Should(Equal("host:9001"))
 		})
 
 		It("should allow setting the datastore credentials file via env var", func() {
@@ -272,9 +272,9 @@ var _ = Describe("Config", func() {
 		})
 
 		It("should allow setting the datastore host via command line", func() {
-			err := cmd.ParseFlags([]string{"--gcloud-emulator-datastore", "host:9001"})
+			err := cmd.ParseFlags([]string{"--gcloud-emulator-datastore-host-port", "host:9001"})
 			Ω(err).ShouldNot(HaveOccurred())
-			Ω(viper.GetString(GCEmulatorDatastoreConfig)).Should(Equal("host:9001"))
+			Ω(viper.GetString(GCEmulatorDatastoreHostPortConfig)).Should(Equal("host:9001"))
 		})
 
 		It("should allow setting the datastore credentials file via command line", func() {


### PR DESCRIPTION
Adding g.e.d.enabled made g.e.d a tree so this
moves the old value into that tree.