### PR TITLE
Logging improvements

### DIFF
--- a/admin/admin_suite_test.go
+++ b/admin/admin_suite_test.go
@@ -2,6 +2,7 @@ package admin_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
 	"testing"
@@ -9,5 +10,6 @@ import (
 
 func TestAdmin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Admin Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Admin Suite", []Reporter{junitReporter})
 }

--- a/auth/auth_suite_test.go
+++ b/auth/auth_suite_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
 	"testing"
@@ -9,5 +10,6 @@ import (
 
 func TestAuth(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Auth Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Auth Suite", []Reporter{junitReporter})
 }

--- a/funcname/funcname_suite_test.go
+++ b/funcname/funcname_suite_test.go
@@ -2,6 +2,7 @@ package funcname_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
 	"testing"
@@ -9,5 +10,6 @@ import (
 
 func TestFuncname(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Funcname Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Funcname Suite", []Reporter{junitReporter})
 }

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,7 @@
 package: github.com/zenoss/zenkit
 import:
+- package: github.com/golang/sync
+  version: fd80eb9
 - package: github.com/Shopify/sarama
   version: 1.12.0
 - package: github.com/bsm/sarama-cluster

--- a/healthcheck/checks/checks_suite_test.go
+++ b/healthcheck/checks/checks_suite_test.go
@@ -5,9 +5,11 @@ import (
 	. "github.com/onsi/gomega"
 
 	"testing"
+	"github.com/onsi/ginkgo/reporters"
 )
 
 func TestChecks(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Checks Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Checks Suite", []Reporter{junitReporter})
 }

--- a/healthcheck/healthcheck_suite_test.go
+++ b/healthcheck/healthcheck_suite_test.go
@@ -2,6 +2,7 @@ package healthcheck_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
 	"testing"
@@ -9,5 +10,6 @@ import (
 
 func TestHealthcheck(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Healthcheck Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Healthcheck Suite", []Reporter{junitReporter})
 }

--- a/logging/log_response.go
+++ b/logging/log_response.go
@@ -1,0 +1,69 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"github.com/goadesign/goa"
+	"github.com/sirupsen/logrus"
+	"github.com/goadesign/goa/middleware"
+)
+
+
+// loggingResponseWriter wraps an http.ResponseWriter and writes only raw
+// response data (as text) to the context logger.
+type loggingResponseWriter struct {
+	http.ResponseWriter
+	ctx context.Context
+}
+
+// Write will write error responses to the logger if debug is enabled
+func (lrw *loggingResponseWriter) Write(buf []byte) (int, error) {
+	entry := ContextLogger(lrw.ctx)
+	if entry != nil {
+		logger := entry.Logger
+		if logger.Level == logrus.DebugLevel {
+			resp := goa.ContextResponse(lrw.ctx)
+			if code := resp.ErrorCode; code != "" {
+				reqID := middleware.ContextRequestID(lrw.ctx)
+				errorResponse := goa.ErrorResponse{}
+				err := json.Unmarshal(buf, &errorResponse)
+				if err == nil {
+					logger.WithFields(logrus.Fields{
+						"req_id":  reqID,
+						"error_id":  errorResponse.ID,
+						"code": errorResponse.Code,
+						"status": errorResponse.Status,
+						"detail": errorResponse.Detail,
+					}).Debug("returned an error")
+				} else {
+					logger.WithError(err).WithFields(logrus.Fields{
+						"req_id":  reqID,
+					}).Error("Unable to unmarshall buffer into ErrorResponse")
+				}
+			}
+		}
+	}
+	return lrw.ResponseWriter.Write(buf)
+}
+
+// LogErrorResponse creates an error response logger middleware.
+// Only logs the error responses if debug logging is enabled.
+// Modeled on middleware.LogResponse
+func LogErrorResponse() goa.Middleware {
+	return func(h goa.Handler) goa.Handler {
+		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			// chain a new logging writer to the current response writer.
+			resp := goa.ContextResponse(ctx)
+			resp.SwitchWriter(
+				&loggingResponseWriter{
+					ResponseWriter: resp.SwitchWriter(nil),
+					ctx:            ctx,
+				})
+
+			// next
+			return h(ctx, rw, req)
+		}
+	}
+}
+

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -7,6 +7,7 @@ import (
 	goalogrus "github.com/goadesign/goa/logging/logrus"
 	"github.com/sirupsen/logrus"
 	"github.com/zenoss/zenkit/funcname"
+	"github.com/goadesign/goa/middleware"
 )
 
 var noop = func() {}
@@ -21,6 +22,14 @@ func ServiceLogger() goa.LogAdapter {
 
 func ContextLogger(ctx context.Context) *logrus.Entry {
 	return goalogrus.Entry(ctx)
+}
+
+func ContextLoggerWithReqId(ctx context.Context) *logrus.Entry {
+	entry := goalogrus.Entry(ctx)
+	if entry == nil {
+		return nil
+	}
+	return entry.WithField("req_id", middleware.ContextRequestID(ctx))
 }
 
 func SetLogLevel(svc *goa.Service, level string) {
@@ -48,7 +57,7 @@ func SetLogLevel(svc *goa.Service, level string) {
 }
 
 func LogEntryAndExit(ctx context.Context) func() {
-	logger := ContextLogger(ctx)
+	logger := ContextLoggerWithReqId(ctx)
 	if logger == nil {
 		return noop
 	}

--- a/logging/logging_suite_test.go
+++ b/logging/logging_suite_test.go
@@ -2,6 +2,7 @@ package logging_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
 	"testing"
@@ -9,5 +10,6 @@ import (
 
 func TestLogging(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Logging Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Logging Suite", []Reporter{junitReporter})
 }

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -4,15 +4,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http/httptest"
+	"net/http"
 
 	"github.com/goadesign/goa"
+	"github.com/goadesign/goa/middleware"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	. "github.com/zenoss/zenkit/logging"
 	"github.com/zenoss/zenkit/test"
 
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/goadesign/goa/middleware"
+	"encoding/json"
 )
 
 func TheTestFunction(ctx context.Context) {
@@ -132,6 +135,130 @@ var _ = Describe("Logging", func() {
 			Ω(entry.Data).Should(HaveKey("req_id"))
 			Ω(entry.Data["req_id"]).Should(Not(BeNil()))
 		})
+	})
+
+	Context("with the error-response middleware logger", func() {
+		var (
+			svc *goa.Service
+			resp   http.ResponseWriter
+			req    *http.Request
+			b      bytes.Buffer
+			logger *logrus.Logger
+		)
+
+		okHandler := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+			goa.ContextResponse(ctx).WriteHeader(200)
+			goa.ContextResponse(ctx).Write([]byte{})
+			return nil
+		}
+
+		BeforeEach(func() {
+			svc = goa.New(test.RandString(8))
+			svc.WithLogger(ServiceLogger())
+			logger = ContextLogger(svc.Context).Logger
+			resp   = httptest.NewRecorder()
+			req, _ = http.NewRequest("", "http://example.com", nil)
+		})
+
+		It("shouldn't panic if there's no logger defined", func() {
+			svc.WithLogger(nil)
+			l := LogErrorResponse()(okHandler)
+			ctx := goa.NewContext(svc.Context, resp, req, nil)
+
+			err := l(ctx, resp, req)
+
+			Ω(err).ShouldNot(HaveOccurred())
+		})
+
+		It("shouldn't log anything if level != debug", func() {
+			SetLogLevel(svc, "info")
+			logger.Out = &b
+			l := LogErrorResponse()(okHandler)
+			ctx := goa.NewContext(svc.Context, resp, req, nil)
+
+			err := l(ctx, resp, req)
+
+			Ω(err).ShouldNot(HaveOccurred())
+			s := b.String()
+			Ω(s).Should(BeEmpty())
+		})
+
+		It("shouldn't log anything if the response is OK", func() {
+			SetLogLevel(svc, "debug")
+			logger.Out = &b
+			l := LogErrorResponse()(okHandler)
+			ctx := goa.NewContext(svc.Context, resp, req, nil)
+
+			err := l(ctx, resp, req)
+
+			Ω(err).ShouldNot(HaveOccurred())
+			s := b.String()
+			Ω(s).Should(BeEmpty())
+		})
+
+		It("should log something if the response is !OK", func() {
+			var errResponse *goa.ErrorResponse
+			SetLogLevel(svc, "debug")
+			logger.Out = &b
+			failHandler := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+				// Simulate GOA detecting a bad request
+				var err error
+				err = goa.ErrBadRequest("fail test")
+				errResponse = err.(*goa.ErrorResponse)
+				ctx = goa.WithError(ctx, errResponse)
+				resp := goa.ContextResponse(ctx)
+				resp.ErrorCode = errResponse.Token()
+				rw.WriteHeader(400)
+				body, _ := json.Marshal(goa.ContextError(ctx))
+				rw.Write(body)
+				return err
+			}
+			l := LogErrorResponse()(failHandler)
+			ctx := goa.NewContext(svc.Context, resp, req, nil)
+
+			err := l(ctx, goa.ContextResponse(ctx), req)
+
+			Ω(err).Should(HaveOccurred())
+			s := b.String()
+			Ω(s).Should(Not(BeEmpty()))
+			Ω(s).Should(ContainSubstring("returned an error"))
+			Ω(s).Should(ContainSubstring(fmt.Sprintf("req_id=%s", middleware.ContextRequestID(ctx))))
+			Ω(s).Should(ContainSubstring(fmt.Sprintf("error_id=%s", errResponse.ID)))
+			Ω(s).Should(ContainSubstring(fmt.Sprintf("code=%s", errResponse.Code)))
+			Ω(s).Should(ContainSubstring(fmt.Sprintf("status=%d", errResponse.Status)))
+			Ω(s).Should(ContainSubstring(fmt.Sprintf("detail=\"%s\"", errResponse.Detail)))
+		})
+
+		It("should log something if the response is not an instance of ErrorResponse", func() {
+			var errResponse *goa.ErrorResponse
+			SetLogLevel(svc, "debug")
+			logger.Out = &b
+			failHandler := func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
+				// Simulate GOA detecting a bad request
+				var err error
+				err = goa.ErrBadRequest("fail test")
+				errResponse = err.(*goa.ErrorResponse)
+				ctx = goa.WithError(ctx, errResponse)
+				resp := goa.ContextResponse(ctx)
+				resp.ErrorCode = errResponse.Token()
+				rw.WriteHeader(400)
+
+				// Do NOT write ErrorResponse to the response body
+				rw.Write([]byte{})
+				return err
+			}
+			l := LogErrorResponse()(failHandler)
+			ctx := goa.NewContext(svc.Context, resp, req, nil)
+
+			err := l(ctx, goa.ContextResponse(ctx), req)
+
+			Ω(err).Should(HaveOccurred())
+			s := b.String()
+			Ω(s).Should(Not(BeEmpty()))
+			Ω(s).Should(ContainSubstring("Unable to unmarshall buffer into ErrorResponse"))
+			Ω(s).Should(ContainSubstring(fmt.Sprintf("req_id=%s", middleware.ContextRequestID(ctx))))
+		})
+
 	})
 
 })

--- a/metrics/metrics_suite_test.go
+++ b/metrics/metrics_suite_test.go
@@ -2,6 +2,7 @@ package metrics_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 
 	"testing"
@@ -9,5 +10,6 @@ import (
 
 func TestMetrics(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Metrics Suite")
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Metrics Suite", []Reporter{junitReporter})
 }

--- a/service.go
+++ b/service.go
@@ -22,6 +22,7 @@ func NewService(name string, authDisabled bool) *goa.Service {
 	svc.Use(middleware.LogRequest(false))
 	svc.Use(metrics.MetricsMiddleware())
 	svc.Use(middleware.ErrorHandler(svc, true))
+	svc.Use(logging.LogErrorResponse())
 	svc.Use(middleware.Recover())
 
 	return svc


### PR DESCRIPTION
1. Add `ContextLoggerWithReqId()` to make it easier to include the zenkit request id in each log message.  The request id (`req_id=` in the log output) is useful for correlating log messages related to a particular HTTP request. To use, an application would log a message like this:
```
    logging.ContextLoggerWithReqId(ctx).WithError(err).Error("error deleting Report")
```

2. Add `LogErrorResponse()` middleware so that, if debug logging is enabled, errors returned directly from goa and be logged. For instance, this is can be useful in debugging malformed requests.  Here's an example of an error returned directly by goa when this middleware is used and debug logging is enabled:
```
reporter_1   | time="2017-12-21T19:41:15Z" level=info msg=started PUT=/api/v1/reports/1 action=update ctrl=ReportController from=172.18.0.4 req_id=fHzn36wgmW-1
reporter_1   | time="2017-12-21T19:41:15Z" level=debug msg="returned an error" code=bad_request detail="failed to decode request body with content type \"application/json;charset=utf-8\": parsing time \"\"2017-12-20 02:01:01.000Z\"\" as \"\"2006-01-02T15:04:05Z07:00\"\": cannot parse \" 02:01:01.000Z\"\" as \"T\"" error_id=07eGUOtf req_id=fHzn36wgmW-1 status=400
reporter_1   | time="2017-12-21T19:41:15Z" level=info msg=completed action=update bytes=274 ctrl=ReportController error=07eGUOtf req_id=fHzn36wgmW-1 status=400 time="510.558µs"
```
The first and last messages are the standard goa log messages for the start and completion of some action. The second message is the one added by `LogErrorResponse()` 