### PR TITLE
Update logrus level when we update ctx log level

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/goadesign/goa"
 	goalogrus "github.com/goadesign/goa/logging/logrus"
+	"github.com/goadesign/goa/middleware"
 	"github.com/sirupsen/logrus"
 	"github.com/zenoss/zenkit/funcname"
-	"github.com/goadesign/goa/middleware"
 )
 
 var noop = func() {}
@@ -49,6 +49,7 @@ func SetLogLevel(svc *goa.Service, level string) {
 		}).Debug("Requested log level is already active. Ignoring.")
 		return
 	}
+	logrus.SetLevel(newlevel)
 	logger.Level = newlevel
 	logger.WithFields(logrus.Fields{
 		"oldlevel": oldlevel,


### PR DESCRIPTION
zenkit logging has it's own instance of a logrus entry, so using logrus.Info(), logrus.Debug(), etc. ignores levels set by the config.
This is a big gotcha, as zenkit deploys lots of logrus logging, so we should update logrus level, too.