### PR TITLE
Add mechanism to collect all metrics on a regular interval

### DIFF
--- a/admin/admin_test.go
+++ b/admin/admin_test.go
@@ -67,6 +67,8 @@ var _ = Describe("Admin", func() {
 
 		Context("when the metrics middleware isn't hooked up", func() {
 			It("should respond OK", func() {
+				s := ContextParentService(ctx)
+				s.Context = metrics.WithMetrics(s.Context, nil)
 				test.MetricsAdminOK(t, ctx, svc, ctrl, false)
 			})
 		})

--- a/glide.yaml
+++ b/glide.yaml
@@ -42,7 +42,7 @@ import:
 - package: github.com/xeipuuv/gojsonreference
   version: e02fc20de94c78484cd5ffb007f8af96be030a45
 - package: github.com/goadesign/goa
-  version: dbf7887cb0defd0b80eda334f3bf2ffa05dbdbc3
+  version: 94c5f00a452130a8732b2e3348eb9259be23a224
   subpackages:
   - design
   - design/apidsl

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/goadesign/goa"
 	metrics "github.com/rcrowley/go-metrics"
 	"github.com/zenoss/zenkit/funcname"
+	"github.com/pkg/errors"
+	"github.com/zenoss/zenkit/logging"
 )
 
 type key int
@@ -28,14 +31,28 @@ func ContextMetrics(ctx context.Context) metrics.Registry {
 }
 
 func MeasureTime(ctx context.Context) func() {
+	return measureTimeNamed(ctx, "")
+}
+
+func MeasureTimeNamed(ctx context.Context, prefix string) func() {
+	return measureTimeNamed(ctx, prefix)
+}
+
+func measureTimeNamed(ctx context.Context, prefix string) func() {
 	begin := TimeFunc()
-	fn := funcname.FuncName(2)
+	fn := funcname.FuncName(3)
+	var name string
+	if len(prefix) == 0 {
+		name = fmt.Sprintf("func.%s.time", fn)
+	} else {
+		name = fmt.Sprintf("%s.func.%s.time", prefix, fn)
+	}
 	registry := ContextMetrics(ctx)
 	exit := func() {
 		if registry == nil {
 			return
 		}
-		t := metrics.GetOrRegisterTimer(fmt.Sprintf("func.%s.time", fn), registry)
+		t := metrics.GetOrRegisterTimer(name, registry)
 		t.UpdateSince(begin)
 	}
 	return exit
@@ -50,11 +67,140 @@ func IncrementCounter(ctx context.Context, name string, inc int64) {
 	ctr.Inc(inc)
 }
 
+func UpdateMeter(ctx context.Context, name string, n int64) {
+	registry := ContextMetrics(ctx)
+	if registry == nil {
+		return
+	}
+	ctr := metrics.GetOrRegisterMeter(name, registry)
+	ctr.Mark(n)
+}
+
 func MetricsMiddleware() goa.Middleware {
-	m := metrics.NewRegistry()
 	return func(h goa.Handler) goa.Handler {
 		return func(ctx context.Context, rw http.ResponseWriter, req *http.Request) error {
-			return h(WithMetrics(ctx, m), rw, req)
+			// if the parent context has a metrics registry already, then use it
+			m := ContextMetrics(ctx)
+			if m == nil {
+				ctx = WithMetrics(ctx, metrics.NewRegistry())
+			}
+			return h(ctx, rw, req)
 		}
 	}
+}
+
+// Metric defines the structure of a single metric returned from CollectMetrics
+type Metric struct {
+	Timestamp float64                `json:"timestamp"`
+	Metric    string                 `json:"metric"`
+	Value     float64                `json:"value"`
+}
+
+// MetricReceiver defines the callback function invoked periodically by CollectMetrics
+type MetricReceiver func(metrics []Metric)
+
+// CollectMetrics periodically collects all codahale metrics in the current metric registry,
+// constructs a list of zenkit Metric values derived from each codahale Metric, and
+// calls the receiver function with the list of zenkit Metric values.
+//
+// freq is the rate at which the metrics will be collected and the receiver function will be called
+//
+// prefix is an optional string that will be used to prefix each name for the zenkit Metric. Metric names in a
+// zenkit Metric will have the format [prefix.]name.valueName where name is the name of the codahale Metric and
+// valueName describes a specific value from that Metric (e.g. 'count', 'min', 'max' etc).
+//
+// cancel is a channel the caller can use to cancel the periodic collection of metrics.
+//
+// receiver is the user-defined function tha will be called with the generated list of zenkit Metric values
+//
+func CollectMetrics(ctx context.Context, freq time.Duration, prefix string, cancel <-chan struct{}, receiver MetricReceiver) error {
+	logger := logging.ContextLogger(ctx).Logger
+
+	registry := ContextMetrics(ctx)
+	if registry == nil {
+		logger.Error("CollectMetrics called before metrics Registry was added to Context")
+		return errors.New("metrics registry not defined")
+	}
+
+	go func() {
+		timer := time.NewTicker(freq)
+		for {
+			select {
+			case <-timer.C:
+				metricList := []Metric{}
+				timestamp := float64(time.Now().Unix())
+				registry.Each(func(name string, m interface{}) {
+					metricList = addMetrics(prefix, name, m, timestamp, metricList)
+				})
+				if len(metricList) == 0 {
+					logger.Debug("CollectMetrics - nothing to report")
+					continue
+				}
+				receiver(metricList)
+			case <-cancel:
+				logger.Info("CollectMetrics cancelled")
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func addMetrics(prefix, name string, m interface{}, timestamp float64, metricList []Metric) []Metric {
+	switch codahaleMetric := m.(type) {
+	case metrics.Counter:
+		metricList = append(metricList, toMetric(metricName(prefix, name, "count"), float64(codahaleMetric.Count()), timestamp))
+
+	case metrics.Meter:
+		metricList = append(metricList, toMetric(metricName(prefix, name, "count"), float64(codahaleMetric.Count()), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "1MinuteRate"), codahaleMetric.Rate1(), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "5MinuteRate"), codahaleMetric.Rate5(), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "15MinuteRate"), codahaleMetric.Rate15(), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "meanRate"), codahaleMetric.RateMean(), timestamp))
+
+	case metrics.Timer:
+		/*
+		 * report the same values reported for Timers in MetricConsumer, adjusting the units for
+		 *    time values to milliseconds instead of nanoseconds
+		 */
+		s := codahaleMetric.Snapshot()
+		units := time.Millisecond
+		unitDivisor := float64(units)
+		metricList = append(metricList, toMetric(metricName(prefix, name, "min"), float64(s.Min())/unitDivisor, timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "max"), float64(s.Max())/unitDivisor, timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "mean"), float64(s.Mean()/unitDivisor), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "stddev"), s.StdDev()/unitDivisor, timestamp))
+
+		ps := s.Percentiles([]float64{0.5, 0.75, 0.95, 0.98, 0.99, 0.999})
+		metricList = append(metricList, toMetric(metricName(prefix, name, "median"),  ps[0]/unitDivisor, timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "p75"),  ps[1]/unitDivisor, timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "p95"),  ps[2]/unitDivisor, timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "p98"),  ps[3]/unitDivisor, timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "p99"),  ps[4]/unitDivisor, timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "p999"),  ps[5]/unitDivisor, timestamp))
+
+		// Add the value which overlap with metrics.Meter
+		metricList = append(metricList, toMetric(metricName(prefix, name, "count"), float64(s.Count()), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "meanRate"), s.RateMean(), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "1MinuteRate"), s.Rate1(), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "5MinuteRate"), s.Rate5(), timestamp))
+		metricList = append(metricList, toMetric(metricName(prefix, name, "15MinuteRate"), s.Rate15(), timestamp))
+	}
+	return metricList
+}
+
+func metricName(prefix, name, valueName string) string {
+	if len(prefix) == 0 {
+		return fmt.Sprintf("%s.%s", name, valueName)
+	}
+	return fmt.Sprintf("%s.%s.%s", prefix, name, valueName)
+}
+
+// toMetric creates a zenkit Metric from a name and value
+func toMetric(name string, value float64, timestamp float64) Metric {
+	metric := Metric{}
+	metric.Metric = name
+	metric.Timestamp = timestamp
+	metric.Value = value
+	return metric
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -6,8 +6,11 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/goadesign/goa"
 	metrics "github.com/rcrowley/go-metrics"
+	"github.com/zenoss/zenkit/logging"
 	. "github.com/zenoss/zenkit/metrics"
+        "github.com/zenoss/zenkit/test"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -15,6 +18,11 @@ import (
 
 func TimedFunc(ctx context.Context) {
 	defer MeasureTime(ctx)()
+	time.Sleep(1 * time.Millisecond)
+}
+
+func TimedFuncWithName(ctx context.Context, prefix string) {
+	defer MeasureTimeNamed(ctx, prefix)()
 	time.Sleep(1 * time.Millisecond)
 }
 
@@ -36,8 +44,8 @@ var _ = Describe("Metrics", func() {
 
 	It("should be able to be registered by middleware", func() {
 		var (
-			m      metrics.Registry
-			resp   = httptest.NewRecorder()
+			m metrics.Registry
+			resp = httptest.NewRecorder()
 			req, _ = http.NewRequest("", "http://example.com", nil)
 		)
 
@@ -61,8 +69,17 @@ var _ = Describe("Metrics", func() {
 		Ω(metric).ShouldNot(BeNil())
 	})
 
+	It("should be able to measure the time for a named timer", func() {
+		reg := metrics.NewRegistry()
+		ctx := WithMetrics(context.Background(), reg)
+		TimedFuncWithName(ctx, "my.timer")
+		metric := reg.Get("my.timer.func.TimedFuncWithName.time")
+		Ω(metric).ShouldNot(BeNil())
+	})
+
 	It("should not panic function metrics if no registry is defined", func() {
-		TimedFunc(context.Background())
+		ctx := WithMetrics(context.Background(), nil)
+		TimedFunc(ctx)
 	})
 
 	It("should be able to increment a counter", func() {
@@ -76,4 +93,148 @@ var _ = Describe("Metrics", func() {
 	It("should not panic counter increment if no registry is defined", func() {
 		IncrementCounter(context.Background(), "my.test.counter", 1)
 	})
+
+	It("should be able to update a meter", func() {
+		reg := metrics.NewRegistry()
+		ctx := WithMetrics(context.Background(), reg)
+		UpdateMeter(ctx, "my.test.meter", 1)
+		metric := reg.Get("my.test.meter")
+		Ω(metric).ShouldNot(BeNil())
+	})
+
+	It("should not panic meter update if no registry is defined", func() {
+		UpdateMeter(context.Background(), "my.test.meter", 1)
+	})
+
+	Context("with CollectMetrics", func() {
+		var (
+			registry metrics.Registry
+			svc      *goa.Service
+			ctx      context.Context
+			cancel   chan struct{}
+		)
+
+		BeforeEach(func() {
+			svc = goa.New(test.RandString(8))
+			svc.WithLogger(logging.ServiceLogger())
+			registry = metrics.NewRegistry()
+			ctx = WithMetrics(svc.Context, registry)
+			cancel = make(chan struct{})
+		})
+
+		AfterEach(func() {
+			close(cancel)
+		})
+
+		It("should not panic if no registry is defined", func() {
+			err := CollectMetrics(svc.Context, time.Second, "prefix", cancel, func(metrics []Metric) {})
+			Ω(err).Should(HaveOccurred())
+			Ω(err).Should(MatchError("metrics registry not defined"))
+		})
+
+		It("should return no metrics if nothing has been added to metric registry", func() {
+			nReceived := 0
+			results   := []Metric{}
+			receiver  := func(metrics []Metric) {
+				nReceived += 1
+				results = append(results, metrics...)
+			}
+			err := CollectMetrics(ctx, time.Second, "prefix", cancel, receiver)
+			Ω(err).Should(Succeed())
+
+			// wait for at least 1 collection cycle
+			time.Sleep(2 * time.Second)
+
+			// the receiver should have been called, but no metrics collected
+			Ω(nReceived).Should(Equal(0))
+			Ω(len(results)).Should(Equal(0))
+		})
+
+		It("should return some Counter metrics if a counter has been incremented", func() {
+			nReceived := 0
+			results   := []Metric{}
+			receiver  := func(metrics []Metric) {
+				nReceived += 1
+				results = append(results, metrics...)
+			}
+			err := CollectMetrics(ctx, time.Second, "prefix", cancel, receiver)
+			Ω(err).Should(Succeed())
+
+			IncrementCounter(ctx, "my.counter", 1)
+
+			// wait for at least 1 collection cycle
+			time.Sleep(2 * time.Second)
+
+			// the receiver should have been called, but no metrics collected
+			Ω(nReceived).ShouldNot(Equal(0))
+			Ω(len(results)).ShouldNot(Equal(0))
+			Ω(results[0].Metric).Should(Equal("prefix.my.counter.count"))
+		})
+
+		It("should return some Meter metrics if a meter has been incremented", func() {
+			nReceived := 0
+			results   := []Metric{}
+			receiver  := func(metrics []Metric) {
+				nReceived += 1
+				results = append(results, metrics...)
+			}
+			err := CollectMetrics(ctx, time.Second, "prefix", cancel, receiver)
+			Ω(err).Should(Succeed())
+
+			UpdateMeter(ctx, "my.meter", 1)
+
+			// wait for at least 1 collection cycle
+			time.Sleep(2 * time.Second)
+
+			// the receiver should have been called, but no metrics collected
+			Ω(nReceived).ShouldNot(Equal(0))
+			Ω(len(results)).ShouldNot(Equal(0))
+			Ω(results[0].Metric).Should(Equal("prefix.my.meter.count"))
+		})
+
+		It("should return some Timer metrics if a timer has been incremented", func() {
+			nReceived := 0
+			results   := []Metric{}
+			receiver  := func(metrics []Metric) {
+				nReceived += 1
+				results = append(results, metrics...)
+			}
+			err := CollectMetrics(ctx, time.Second, "prefix", cancel, receiver)
+			Ω(err).Should(Succeed())
+
+			MeasureTime(ctx)()
+
+			// wait for at least 1 collection cycle
+			time.Sleep(2 * time.Second)
+
+			// the receiver should have been called, but no metrics collected
+			Ω(nReceived).ShouldNot(Equal(0))
+			Ω(len(results)).ShouldNot(Equal(0))
+			Ω(results[0].Metric).Should(ContainSubstring("prefix"))
+			Ω(results[0].Metric).Should(ContainSubstring("time"))
+		})
+
+		It("should return some metrics even if prefix is empty", func() {
+			nReceived := 0
+			results   := []Metric{}
+			receiver  := func(metrics []Metric) {
+				nReceived += 1
+				results = append(results, metrics...)
+			}
+			err := CollectMetrics(ctx, time.Second, "", cancel, receiver)
+			Ω(err).Should(Succeed())
+
+			IncrementCounter(ctx, "my.counter", 1)
+
+			// wait for at least 1 collection cycle
+			time.Sleep(2 * time.Second)
+
+			// the receiver should have been called, but no metrics collected
+			Ω(nReceived).ShouldNot(Equal(0))
+			Ω(len(results)).ShouldNot(Equal(0))
+			Ω(results[0].Metric).Should(Equal("my.counter.count"))
+		})
+
+	})
+
 })


### PR DESCRIPTION
Also includes changes for:
* `UpdateMeter ()` - collects Meter style metrics
* `MeasureTimeNamed ()` - includes an application-defined prefix to Timer metric names (e.g. create "api.zing-connector.func.PublishModels.time" instead of just "func.PublishModels.time")